### PR TITLE
Fix wrong type error in sampling function

### DIFF
--- a/lab2/Part2_debiasing.ipynb
+++ b/lab2/Part2_debiasing.ipynb
@@ -636,11 +636,9 @@
         "\"\"\"\n",
         "def sampling(args):\n",
         "    z_mean, z_logsigma = args\n",
-        "    batch = z_mean.shape[0]\n",
-        "    dim = z_mean.shape[1]\n",
         "    \n",
         "    # by default, random_normal has mean=0 and std=1.0\n",
-        "    epsilon = tf.random_normal(shape=(batch, dim))\n",
+        "    epsilon = tf.random_normal(shape=tf.shape(z_mean))\n",
         "    '''TODO: Define the reparameterization computation using the equation in the text above.'''\n",
         "    z = # TODO\n",
         "    return z"


### PR DESCRIPTION
As is in the sampling function tf.random_normal wants a 1-d int tensor as input for shape, but we are passing in a tuple which causes errors.