### PR TITLE
fix `sparse_categorical_crossentropy` documentation in Lab1 Part 2

### DIFF
--- a/lab1/Part2_Music_Generation.ipynb
+++ b/lab1/Part2_Music_Generation.ipynb
@@ -656,7 +656,7 @@
         "\n",
         "At this point, we can think of our next character prediction problem as a standard classification problem. Given the previous state of the RNN, as well as the input at a given time step, we want to predict the class of the next character -- that is, to actually predict the next character. \n",
         "\n",
-        "To train our model on this classification task, we can use a form of the `crossentropy` loss (negative log likelihood loss). Specifically, we will use the [`sparse_categorical_crossentropy`](https://www.tensorflow.org/api_docs/python/tf/keras/backend/sparse_categorical_crossentropy) loss, as it utilizes integer targets for categorical classification tasks. We will want to compute the loss using the true targets -- the `labels` -- and the predicted targets -- the `logits`.\n",
+        "To train our model on this classification task, we can use a form of the `crossentropy` loss (negative log likelihood loss). Specifically, we will use the [`sparse_categorical_crossentropy`](https://www.tensorflow.org/api_docs/python/tf/keras/losses/sparse_categorical_crossentropy) loss, as it utilizes integer targets for categorical classification tasks. We will want to compute the loss using the true targets -- the `labels` -- and the predicted targets -- the `logits`.\n",
         "\n",
         "Let's first compute the loss using our example predictions from the untrained model: "
       ]


### PR DESCRIPTION
We should use `sparse_categorical_crossentropy` from `tf.keras.losses` not `tf.keras.backend`

because `tf.keras.losses.sparse_categorical_crossentropy` takes in a list of truth values, whereas `tf.keras.backend.sparse_categorical_crossentropy` takes in an integer tensor (which is not what we have).

Code is right, just the link to documentation is wrong.