### PR TITLE
Minor fix: Lab1 Part 2.3 Range of indices for vocab

### DIFF
--- a/lab1/Part2_Music_Generation.ipynb
+++ b/lab1/Part2_Music_Generation.ipynb
@@ -236,7 +236,7 @@
         "id": "tZfqhkYCymwX"
       },
       "source": [
-        "This gives us an integer representation for each character. Observe that the unique characters (i.e., our vocabulary) in the text are mapped as indices from 0 to `len(unique)`. Let's take a peek at this numerical representation of our dataset:"
+        "This gives us an integer representation for each character. Observe that the unique characters (i.e., our vocabulary) in the text are mapped as indices from 0 to `len(unique) - 1`. Let's take a peek at this numerical representation of our dataset:"
       ]
     },
     {


### PR DESCRIPTION
I suppose Range of indices for vocab (unique characters) should be '0 to len(unique) - 1' instead of  '0 to len(unique)'
Sorry if nitpicking.