### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,9 @@ install_deps = [
     'numpy',
     'regex',
     'tqdm',
-    'gym'
-
+    'gym',
+    'matplotlib',
+    'opencv-python'
 ]
 tf_ver = '2.0.0a'
 if get_dist('tensorflow>='+tf_ver) is None and get_dist('tensorflow_gpu>='+tf_ver) is None:


### PR DESCRIPTION
Two missing install dependencies are added. However, obencv should be installed preferably with conda if available as environment setup with:

conda install conda-forge::opencv