### PR TITLE
Add local setup using uv package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,50 @@ On this Github repo, navigate to the lab folder you want to run (`lab1`, `lab2`,
 ## Running the labs
 Now, to run the labs, open the Jupyter notebook on Colab. Navigate to the "Runtime" tab --> "Change runtime type". In the pop-up window, under "Runtime type" select "Python 3", and under "Hardware accelerator" select "GPU". Go through the notebooks and fill in the `#TODO` cells to get the code to compile for yourself!
 
+## Running the labs locally with uv
+
+If you prefer to run the notebooks locally you can use the project's `uv` environment tool (used in this repo). The basic workflow is:
+
+1. Open PowerShell and change to the repository root directory:
+
+```powershell
+cd \path\to\introtodeeplearning
+```
+
+2. (Optional) Verify your Python version matches the project's `requires-python` (see `pyproject.toml`):
+
+```powershell
+python --version
+```
+
+3. Install the project dependencies into the `uv` environment. The dependencies and any custom package indexes are declared in `pyproject.toml`. To install everything at once run:
+
+```powershell
+uv sync
+```
+
+This will install all dependencies listed in `pyproject.toml` and automatically use any indexes defined there (for example, the PyTorch CUDA index declared in this repo).
+
+Notes:
+- If `cu126` is incompatible with your machine, simply edit `pyproject.toml` and change the `url` value to the desired CUDA tag. For example, to use CUDA 12.1 change the URL to:
+
+```toml
+[[tool.uv.index]]
+name = "pytorch"
+url = "https://download.pytorch.org/whl/cu121"
+```
+
+You can use the PyTorch get-started selector (https://pytorch.org/get-started/locally/) to find the appropriate index URL.
+
+This keeps the index configuration in a single place and makes it easy to switch CUDA versions for all contributors.
+
+4. Start Jupyter Notebook or JupyterLab from the `uv` environment:
+
+```powershell
+uv run jupyter notebook
+# or
+uv run jupyter lab
+```
 
 ### MIT Deep Learning package
 You might notice that inside the labs we install the `mitdeeplearning` python package from the Python Package repository:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ On this Github repo, navigate to the lab folder you want to run (`lab1`, `lab2`,
 ## Running the labs
 Now, to run the labs, open the Jupyter notebook on Colab. Navigate to the "Runtime" tab --> "Change runtime type". In the pop-up window, under "Runtime type" select "Python 3", and under "Hardware accelerator" select "GPU". Go through the notebooks and fill in the `#TODO` cells to get the code to compile for yourself!
 
-## Running the labs locally with uv
+## Running the labs locally with uv (only for PyTorch labs)
 
 If you prefer to run the notebooks locally you can use the project's `uv` environment tool (used in this repo). The basic workflow is:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,23 @@ readme = "README.md"
 requires-python = ">=3.12,<3.13"
 dependencies = [
     "comet-ml>=3.54.0",
+    "datasets>=2.19.1",
     "dotenv>=0.9.9",
+    "gym>=0.26.2",
+    "lion-pytorch>=0.2.3",
     "matplotlib>=3.10.7",
     "mitdeeplearning>=0.7.5",
+    "numpy>=2.1.2",
+    "openai>=2.7.1",
     "opencv-python>=4.12.0.88",
+    "opik>=1.8.99",
+    "peft>=0.17.1",
+    "regex>=2025.11.3",
     "scipy>=1.16.3",
     "torch>=2.9.0",
     "torchvision>=0.24.0",
+    "tqdm>=4.66.5",
+    "transformers>=4.57.1",
 ]
 
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "introtodeeplearning"
+version = "0.7.5"
+license = "MIT"
+description = "Lab Materials for MIT 6.S191: Introduction to Deep Learning"
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+dependencies = [
+    "comet-ml>=3.54.0",
+    "dotenv>=0.9.9",
+    "matplotlib>=3.10.7",
+    "mitdeeplearning>=0.7.5",
+    "opencv-python>=4.12.0.88",
+    "scipy>=1.16.3",
+    "torch>=2.9.0",
+    "torchvision>=0.24.0",
+]
+
+[[tool.uv.index]]
+name = "pytorch"
+url = "https://download.pytorch.org/whl/cu126"


### PR DESCRIPTION
# Motivation

The Google Colab Free plan has a very limited GPU quota (https://github.com/MITDeepLearning/introtodeeplearning/issues/201) that makes it difficult to complete the labs effectively. Once the quota is exhausted, users are forced to wait extended periods before regaining GPU access. This PR adds support for running labs locally using the uv package manager, allowing students to:

- Run labs locally with their own GPU hardware without quota restrictions
- Work continuously without GPU access interruptions
- Use familiar local development tools (VS Code, Jupyter)

# Changes
- Added `pyproject.toml`
    - All required dependencies and versions
    - PyTorch CUDA index configuration
    - Python version constraints

- Updated README with new "Running the labs locally with uv" section that explains:
    - How to install dependencies using uv sync
    - How to switch CUDA versions by editing the PyTorch index URL
    - How to launch Jupyter from the uv environment
    
# Notes for Reviewers
- Only added dependencies for PyTorch labs.
- The default CUDA version is set to 12.6, but can be easily changed in ´pyproject.toml´
- Dependencies are pinned to minimum versions to maintain compatibility
- Python version is set to 3.12 to match the current Colab environment