### PR TITLE
Fix output variable in printf

### DIFF
--- a/lab1/PT_Part1_Intro.ipynb
+++ b/lab1/PT_Part1_Intro.ipynb
@@ -425,8 +425,8 @@
         "x_input = torch.tensor([[1, 2.]])\n",
         "model_output = model(x_input)\n",
         "print(f\"input shape: {x_input.shape}\")\n",
-        "print(f\"output shape: {y.shape}\")\n",
-        "print(f\"output result: {y}\")"
+        "print(f\"output shape: {model_output.shape}\")\n",
+        "print(f\"output result: {model_output}\")"
       ]
     },
     {

--- a/lab1/PT_Part1_Intro.ipynb
+++ b/lab1/PT_Part1_Intro.ipynb
@@ -547,7 +547,9 @@
         "out_with_identity = # TODO\n",
         "\n",
         "print(f\"input: {x_input}\")\n",
-        "print(\"Network linear output: {}; network identity output: {}\".format(out_with_linear, out_with_identity))"
+        "print(\"Network linear output: {}; network identity output: {}\".format(out_with_linear, out_with_identity))",
+        "\n"
+        "assert torch.equal(x_input, out_with_identity)"
       ]
     },
     {


### PR DESCRIPTION
Fix output variable in printf in the "Defining a neural network using the PyTorch Sequential API" section. In the current state it prints output from previous section.

Also added an assertion in "Test the Identity Model" section