### PR TITLE
fix(lab1 PT_Part1): print model_output instead of undefined y in Linear example

### DIFF
--- a/lab1/PT_Part1_Intro.ipynb
+++ b/lab1/PT_Part1_Intro.ipynb
@@ -425,8 +425,8 @@
         "x_input = torch.tensor([[1, 2.]])\n",
         "model_output = model(x_input)\n",
         "print(f\"input shape: {x_input.shape}\")\n",
-        "print(f\"output shape: {y.shape}\")\n",
-        "print(f\"output result: {y}\")"
+        "print(f\"output shape: {model_output.shape}\")\n",
+        "print(f\"output result: {model_output}\")"
       ]
     },
     {

--- a/lab1/solutions/PT_Part1_Intro_Solution.ipynb
+++ b/lab1/solutions/PT_Part1_Intro_Solution.ipynb
@@ -511,8 +511,8 @@
         "x_input = torch.tensor([[1, 2.]])\n",
         "model_output = model(x_input)\n",
         "print(f\"input shape: {x_input.shape}\")\n",
-        "print(f\"output shape: {y.shape}\")\n",
-        "print(f\"output result: {y}\")"
+        "print(f\"output shape: {model_output.shape}\")\n",
+        "print(f\"output result: {model_output}\")"
       ]
     },
     {


### PR DESCRIPTION
## Summary

The PyTorch *Neural networks in PyTorch* cell in \`lab1/PT_Part1_Intro.ipynb\` (and its solutions copy) does:

\`\`\`python
x_input = torch.tensor([[1, 2.]])
model_output = model(x_input)
print(f\"input shape: {x_input.shape}\")
print(f\"output shape: {y.shape}\")   # <-- wrong variable
print(f\"output result: {y}\")        # <-- wrong variable
\`\`\`

There's no \`y\` bound in this cell (it was bound in an earlier OurDenseLayer cell), so running this cell in isolation raises \`NameError\`, and running it after the earlier cell prints the stale tensor. Updated both print calls to use \`model_output\`, matching the assignment.

Closes #216

## Testing

Docs/notebook change; only the two print lines in the affected cell are modified. Solutions notebook updated the same way.